### PR TITLE
Update the xsd core version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina
-version=1.2.1-SNAPSHOT
+version=1.3.0-SNAPSHOT
 
 # Dependencies
 ballerinaLangVersion=2201.11.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ ballerinaGradlePluginVersion=2.3.0
 
 wsdl4jVersion=1.6.3
 apacheXmlSchemaVersion=1.4.7
-xsdCoreVersion=1.1.2
+xsdCoreVersion=1.4.0
 picocliVersion=4.0.1
 junitVersion=4.13.1
 junitEngineVersion=5.8.2

--- a/module-ballerina-wsdl/BalTool.toml
+++ b/module-ballerina-wsdl/BalTool.toml
@@ -2,13 +2,13 @@
 id = "wsdl"
 
 [[dependency]]
-path = "../wsdl-cli/build/libs/wsdl-cli-1.2.0.jar"
+path = "../wsdl-cli/build/libs/wsdl-cli-1.3.0-SNAPSHOT.jar"
 
 [[dependency]]
-path = "../wsdl-core/build/libs/wsdl-core-1.2.0.jar"
+path = "../wsdl-core/build/libs/wsdl-core-1.3.0-SNAPSHOT.jar"
 
 [[dependency]]
-path = "lib/xsd-core-1.1.2.jar"
+path = "lib/xsd-core-1.4.0.jar"
 
 [[dependency]]
 path = "lib/wsdl4j-1.6.3.jar"

--- a/module-ballerina-wsdl/Ballerina.toml
+++ b/module-ballerina-wsdl/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.11.0"
 org = "ballerina"
 name = "wsdltool"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Ballerina"]
 keywords = ["wsdl"]
 repository = "https://github.com/ballerina-platform/wsdl-tools"
@@ -14,5 +14,5 @@ observabilityIncluded = false
 [[platform.java21.dependency]]
 groupId = "io.ballerina"
 artifactId = "xsd-core"
-version = "1.1.2"
-path = "lib/xsd-core-1.1.2.jar"
+version = "1.4.0"
+path = "lib/xsd-core-1.4.0.jar"

--- a/module-ballerina-wsdl/Dependencies.toml
+++ b/module-ballerina-wsdl/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.11.0"
 [[package]]
 org = "ballerina"
 name = "wsdltool"
-version = "1.2.0"
+version = "1.3.0"
 modules = [
 	{org = "ballerina", packageName = "wsdltool", moduleName = "wsdltool"}
 ]


### PR DESCRIPTION
## Purpose
> This is to update the following version in the repository.

- XSD-core version : `1.4.0`
- WSDL tool version: `1.3.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the WSDL tools package and its dependencies to newer versions, improving compatibility and incorporating updates from the XSD core library.

## Changes

- **Project Version**: Incremented from `1.2.1-SNAPSHOT` to `1.3.0-SNAPSHOT` in `gradle.properties`
- **XSD Core Dependency**: Updated from version `1.1.2` to `1.4.0` across all configuration files
- **WSDL Tool Components**: Updated `wsdl-cli` and `wsdl-core` from version `1.2.0` to `1.3.0-SNAPSHOT` in tool dependencies
- **Package Versions**: Updated the `wsdltool` package version from `1.2.0` to `1.3.0` in `Ballerina.toml` and `Dependencies.toml`

All changes are coordinated across configuration files including `gradle.properties`, `BalTool.toml`, `Ballerina.toml`, and `Dependencies.toml` to maintain consistency with the new version scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->