### PR TITLE
Support one-way operations in the WSDL tool

### DIFF
--- a/wsdl-core/src/main/java/io/ballerina/wsdl/core/Utils.java
+++ b/wsdl-core/src/main/java/io/ballerina/wsdl/core/Utils.java
@@ -97,6 +97,19 @@ public final class Utils {
                                WHITESPACE + responseFieldName + QUESTION_MARK + SEMICOLON, false);
     }
 
+    public static void generateOneWayTypeDefinitions(String namespace, Map<String, ModuleMemberDeclarationNode> nodes,
+                                                    String requestType, String requestFieldName,
+                                                    OperationContext operation) {
+        String requestBody = String.format(XMLDATA_NAMESPACE, SOAP, namespace) + LINE_BREAK +
+                operation.requestBodyName() + WHITESPACE + BODY_FIELD;
+        String requestHeader = String.format(XMLDATA_NAMESPACE, SOAP, namespace) + LINE_BREAK +
+                operation.requestHeaderName() + WHITESPACE + HEADER + QUESTION_MARK + SEMICOLON;
+        generateTypeDefinition(namespace, nodes, operation.requestName(),
+                   requestHeader + requestBody, true);
+        generateTypeDefinition(namespace, nodes, operation.requestBodyName(), requestType +
+                               WHITESPACE + requestFieldName + QUESTION_MARK + SEMICOLON, false);
+    }
+
     private static void generateTypeDefinition(String namespace, Map<String, ModuleMemberDeclarationNode> nodes,
                                                String typeName, String bodyContent, boolean includeXmlData) {
         StringBuilder builder = new StringBuilder();

--- a/wsdl-core/src/main/java/io/ballerina/wsdl/core/WsdlToBallerina.java
+++ b/wsdl-core/src/main/java/io/ballerina/wsdl/core/WsdlToBallerina.java
@@ -137,6 +137,7 @@ public class WsdlToBallerina {
     public static final String RESULT = "result";
     public static final String ARROW = "->";
     public static final String SEND_RECEIVE = "sendReceive";
+    public static final String SEND_ONLY = "sendOnly";
     public static final String XMLDATA_TO_XML = "xmldata:toXml";
     public static final String QUOTATION_MARK = "\"";
     public static final String XMLDATA_PARSE_AS_TYPE = "xmldata:parseAsType";
@@ -272,13 +273,18 @@ public class WsdlToBallerina {
         String requestType = getElementType(operation.getOperationInput(), getWsdlDefinition(), nodes);
         String requestFieldName = isSimpleType(requestType)
                 ? getElementName(operation.getOperationInput(), getWsdlDefinition()) : requestType;
-        String responseType = getElementType(operation.getOperationOutput(), getWsdlDefinition(), nodes);
-        String responseFieldName = isSimpleType(responseType)
-                ? getElementName(operation.getOperationOutput(), getWsdlDefinition()) : responseType;
         String suffix = soapPorts.size() > 1 ? convertToPascalCase(port.getName()) : EMPTY_STRING;
         OperationContext operationContext = new OperationContext(operation.getOperationName(), suffix);
-        Utils.generateTypeDefinitions(getSoapNamespace(), nodes, requestType, requestFieldName, responseType,
-                                      responseFieldName, operationContext);
+        if (operation.isOneWay()) {
+            Utils.generateOneWayTypeDefinitions(getSoapNamespace(), nodes, requestType, requestFieldName,
+                                                operationContext);
+        } else {
+            String responseType = getElementType(operation.getOperationOutput(), getWsdlDefinition(), nodes);
+            String responseFieldName = isSimpleType(responseType)
+                    ? getElementName(operation.getOperationOutput(), getWsdlDefinition()) : responseType;
+            Utils.generateTypeDefinitions(getSoapNamespace(), nodes, requestType, requestFieldName, responseType,
+                                          responseFieldName, operationContext);
+        }
         ModuleMemberDeclarationNode headerNode = generateHeaderNode(operation, operationContext, resolvedNameMeta);
         nodes.put(operation.getOperationName() + HEADER, headerNode);
         return operationContext;
@@ -342,8 +348,14 @@ public class WsdlToBallerina {
         for (WsdlOperation operation: operations) {
             OperationContext operationContext = generateEnvelopeTypes(operation, nodes, port,
                     response.getResolvedNameMeta());
-            String functionCode = buildRemoteFunctionCode(operationContext, operation.getOperationName(),
-                    operation.getOperationAction());
+            String functionCode;
+            if (operation.isOneWay()) {
+                functionCode = buildOneWayRemoteFunctionCode(operationContext, operation.getOperationName(),
+                        operation.getOperationAction());
+            } else {
+                functionCode = buildRemoteFunctionCode(operationContext, operation.getOperationName(),
+                        operation.getOperationAction());
+            }
             stringBuilder.append(functionCode);
         }
         stringBuilder.append(CLOSE_BRACES);
@@ -382,6 +394,24 @@ public class WsdlToBallerina {
             .append(QUOTATION_MARK).append(CLOSE_PARENTHESIS).append(SEMICOLON)
             .append(RETURN).append(WHITESPACE).append(XMLDATA_PARSE_AS_TYPE)
             .append(OPEN_PARENTHESIS).append(RESULT).append(CLOSE_PARENTHESIS).append(SEMICOLON)
+            .append(CLOSE_BRACES)
+            .toString();
+    }
+
+    private static String buildOneWayRemoteFunctionCode(OperationContext operationContext, String operationName,
+                                                        String operationAction) {
+        return new StringBuilder()
+            .append(REMOTE).append(WHITESPACE).append(ISOLATED).append(WHITESPACE).append(FUNCTION)
+            .append(WHITESPACE).append(convertToCamelCase(operationName))
+            .append(OPEN_PARENTHESIS).append(operationContext.requestName()).append(WHITESPACE).append(ENVELOPE)
+            .append(CLOSE_PARENTHESIS).append(WHITESPACE).append(RETURNS).append(WHITESPACE)
+            .append(ERROR_OR_NIL).append(WHITESPACE)
+            .append(OPEN_BRACES)
+            .append(CHECK).append(WHITESPACE).append(SELF).append(DOT).append(CLIENT_ENDPOINT_FIELD)
+            .append(ARROW).append(SEND_ONLY).append(OPEN_PARENTHESIS).append(CHECK).append(WHITESPACE)
+            .append(XMLDATA_TO_XML).append(OPEN_PARENTHESIS).append(ENVELOPE).append(CLOSE_PARENTHESIS)
+            .append(COMMA).append(WHITESPACE).append(QUOTATION_MARK).append(operationAction)
+            .append(QUOTATION_MARK).append(CLOSE_PARENTHESIS).append(SEMICOLON)
             .append(CLOSE_BRACES)
             .toString();
     }
@@ -513,28 +543,37 @@ public class WsdlToBallerina {
             WsdlOperation wsdlOperation = getWsdlOperation(bindingOperation);
             Objects.requireNonNull(bindingOperation.getBindingInput(),
                     "Invalid binding operation: Binding input is null.");
-            Objects.requireNonNull(bindingOperation.getBindingOutput(),
-                    "Invalid binding operation: Binding output is null.");
+            boolean isOneWay = bindingOperation.getBindingOutput() == null
+                    && bindingOperation.getOperation().getOutput() == null;
+            if (!isOneWay) {
+                Objects.requireNonNull(bindingOperation.getBindingOutput(),
+                        "Invalid binding operation: Binding output is null.");
+            }
             String inputPayload = bindingOperation.getBindingInput().getName();
-            String outputPayload = bindingOperation.getBindingOutput().getName();
+            String outputPayload = isOneWay ? null : bindingOperation.getBindingOutput().getName();
             Map<String, HeaderPart> headerParts = new HashMap<>();
             String inputHeaderName = generateSOAPInputHeaderParts(bindingOperation, headerParts, getSoapVersion());
             Objects.requireNonNull(bindingOperation.getOperation().getInput().getMessage(),
                     "Message element is missing in the input of the operation: " +
                     bindingOperation.getOperation().getName());
-            Objects.requireNonNull(bindingOperation.getOperation().getOutput().getMessage(),
-                    "Message element is missing in the output of the operation: " +
-                    bindingOperation.getOperation().getName());
+            if (!isOneWay) {
+                Objects.requireNonNull(bindingOperation.getOperation().getOutput().getMessage(),
+                        "Message element is missing in the output of the operation: " +
+                        bindingOperation.getOperation().getName());
+            }
             inputPayload = (inputPayload == null)
                     ? bindingOperation.getOperation().getInput().getMessage().getQName().getLocalPart()
                     : inputPayload;
-            outputPayload = (outputPayload == null)
-                    ? bindingOperation.getOperation().getOutput().getMessage().getQName().getLocalPart()
-                    : outputPayload;
+            if (!isOneWay) {
+                outputPayload = (outputPayload == null)
+                        ? bindingOperation.getOperation().getOutput().getMessage().getQName().getLocalPart()
+                        : outputPayload;
+            }
             wsdlOperation = wsdlOperation.toBuilder()
                     .setOperationName(bindingOperation.getOperation().getName())
                     .setOperationInput(inputPayload)
                     .setOperationOutput(outputPayload)
+                    .setOneWay(isOneWay)
                     .setInputHeaderName(inputHeaderName)
                     .setHeaderElements(headerParts)
                     .build();

--- a/wsdl-core/src/main/java/io/ballerina/wsdl/core/WsdlToBallerina.java
+++ b/wsdl-core/src/main/java/io/ballerina/wsdl/core/WsdlToBallerina.java
@@ -390,8 +390,8 @@ public class WsdlToBallerina {
             .append(WHITESPACE).append(CHECK).append(WHITESPACE).append(SELF).append(DOT).append(CLIENT_ENDPOINT_FIELD)
             .append(ARROW).append(SEND_RECEIVE).append(OPEN_PARENTHESIS).append(CHECK).append(WHITESPACE)
             .append(XMLDATA_TO_XML).append(OPEN_PARENTHESIS).append(ENVELOPE).append(CLOSE_PARENTHESIS)
-            .append(COMMA).append(WHITESPACE).append(QUOTATION_MARK).append(operationAction)
-            .append(QUOTATION_MARK).append(CLOSE_PARENTHESIS).append(SEMICOLON)
+            .append(COMMA).append(WHITESPACE).append(buildActionArg(operationAction))
+            .append(CLOSE_PARENTHESIS).append(SEMICOLON)
             .append(RETURN).append(WHITESPACE).append(XMLDATA_PARSE_AS_TYPE)
             .append(OPEN_PARENTHESIS).append(RESULT).append(CLOSE_PARENTHESIS).append(SEMICOLON)
             .append(CLOSE_BRACES)
@@ -410,10 +410,17 @@ public class WsdlToBallerina {
             .append(CHECK).append(WHITESPACE).append(SELF).append(DOT).append(CLIENT_ENDPOINT_FIELD)
             .append(ARROW).append(SEND_ONLY).append(OPEN_PARENTHESIS).append(CHECK).append(WHITESPACE)
             .append(XMLDATA_TO_XML).append(OPEN_PARENTHESIS).append(ENVELOPE).append(CLOSE_PARENTHESIS)
-            .append(COMMA).append(WHITESPACE).append(QUOTATION_MARK).append(operationAction)
-            .append(QUOTATION_MARK).append(CLOSE_PARENTHESIS).append(SEMICOLON)
+            .append(COMMA).append(WHITESPACE).append(buildActionArg(operationAction))
+            .append(CLOSE_PARENTHESIS).append(SEMICOLON)
             .append(CLOSE_BRACES)
             .toString();
+    }
+
+    private static String buildActionArg(String operationAction) {
+        if (operationAction == null) {
+            return OPEN_PARENTHESIS + CLOSE_PARENTHESIS;
+        }
+        return QUOTATION_MARK + operationAction + QUOTATION_MARK;
     }
 
     private static NodeList<ImportDeclarationNode> createImportNodes(String... importStatements) {

--- a/wsdl-core/src/main/java/io/ballerina/wsdl/core/handler/model/WsdlOperation.java
+++ b/wsdl-core/src/main/java/io/ballerina/wsdl/core/handler/model/WsdlOperation.java
@@ -36,6 +36,7 @@ public class WsdlOperation {
     private final String operationUri;
     private final String inputHeaderName;
     private final Map<String, HeaderPart> headerElements;
+    private final boolean oneWay;
 
     private WsdlOperation(Builder builder) {
         this.operationAction = builder.operationAction;
@@ -45,6 +46,7 @@ public class WsdlOperation {
         this.operationName = builder.operationName;
         this.headerElements = builder.headerElements;
         this.inputHeaderName = builder.inputHeaderName;
+        this.oneWay = builder.oneWay;
     }
 
     public String getOperationName() {
@@ -75,6 +77,10 @@ public class WsdlOperation {
         return inputHeaderName;
     }
 
+    public boolean isOneWay() {
+        return oneWay;
+    }
+
     public Builder toBuilder() {
         return new Builder(this);
     }
@@ -87,6 +93,7 @@ public class WsdlOperation {
         private String operationUri;
         private String inputHeaderName;
         private Map<String, HeaderPart> headerElements = new HashMap<>();
+        private boolean oneWay;
 
         public Builder(String operationName) {
             this.operationName = operationName;
@@ -100,6 +107,7 @@ public class WsdlOperation {
             this.operationUri = wsdlOperation.operationUri;
             this.headerElements = wsdlOperation.headerElements;
             this.inputHeaderName = wsdlOperation.inputHeaderName;
+            this.oneWay = wsdlOperation.oneWay;
         }
 
         public Builder setOperationName(String operationName) {
@@ -141,6 +149,11 @@ public class WsdlOperation {
 
         public Builder setInputHeaderName(String inputHeaderName) {
             this.inputHeaderName = inputHeaderName;
+            return this;
+        }
+
+        public Builder setOneWay(boolean oneWay) {
+            this.oneWay = oneWay;
             return this;
         }
 

--- a/wsdl-core/src/test/java/io/ballerina/wsdl/core/WsdlTest.java
+++ b/wsdl-core/src/test/java/io/ballerina/wsdl/core/WsdlTest.java
@@ -178,4 +178,56 @@ public class WsdlTest {
                 "Message element is missing in the input of the operation: multiply";
         Assert.assertEquals(result.get(0).toString(), expectedError);
     }
+
+    @org.junit.jupiter.api.Test
+    void testOneWayOperation() throws Exception {
+        WsdlCmd wsdlCmd = new WsdlCmd();
+        WsdlToBallerinaResponse response = wsdlCmd.wsdlToBallerina(String.valueOf(RES_DIR.resolve(WSDL_DIR).resolve(
+                "one_way_operation.wsdl")), "", new String[]{"urn:ping"});
+        Assert.assertTrue(response.getDiagnostics().isEmpty(),
+                "One-way operation should not produce errors");
+        Assert.assertFalse(response.getClientSources().isEmpty(),
+                "Client source should be generated for one-way operation");
+        String clientContent = response.getClientSources().get(0).content();
+        Assert.assertTrue(clientContent.contains("sendOnly"),
+                "One-way operation should use sendOnly");
+        Assert.assertTrue(clientContent.contains("returns error?"),
+                "One-way operation should return error?");
+        Assert.assertFalse(clientContent.contains("sendReceive"),
+                "One-way operation should not use sendReceive");
+        Assert.assertFalse(clientContent.contains("SoapResponse"),
+                "One-way operation should not generate response types");
+    }
+
+    @org.junit.jupiter.api.Test
+    void testCombinedOneWayAndTwoWayOperations() throws Exception {
+        WsdlCmd wsdlCmd = new WsdlCmd();
+        WsdlToBallerinaResponse response = wsdlCmd.wsdlToBallerina(String.valueOf(RES_DIR.resolve(WSDL_DIR).resolve(
+                "combined_one_way_operation.wsdl")), "", new String[]{"urn:echo", "urn:ping"});
+        Assert.assertTrue(response.getDiagnostics().isEmpty(),
+                "Combined one-way and two-way operations should not produce errors");
+        Assert.assertFalse(response.getClientSources().isEmpty(),
+                "Client source should be generated");
+        String clientContent = response.getClientSources().get(0).content();
+        Assert.assertTrue(clientContent.contains("sendOnly"),
+                "One-way operation should use sendOnly");
+        Assert.assertTrue(clientContent.contains("sendReceive"),
+                "Two-way operation should use sendReceive");
+    }
+
+    @org.junit.jupiter.api.Test
+    void testCombinedWsdlWithTwoWayFilterOnly() throws Exception {
+        WsdlCmd wsdlCmd = new WsdlCmd();
+        WsdlToBallerinaResponse response = wsdlCmd.wsdlToBallerina(String.valueOf(RES_DIR.resolve(WSDL_DIR).resolve(
+                "combined_one_way_operation.wsdl")), "", new String[]{"urn:echo"});
+        Assert.assertTrue(response.getDiagnostics().isEmpty(),
+                "Filtering to two-way operation in WSDL with one-way ops should not produce errors");
+        Assert.assertFalse(response.getClientSources().isEmpty(),
+                "Client source should be generated");
+        String clientContent = response.getClientSources().get(0).content();
+        Assert.assertTrue(clientContent.contains("sendReceive"),
+                "Filtered two-way operation should use sendReceive");
+        Assert.assertFalse(clientContent.contains("sendOnly"),
+                "Filtered result should not contain one-way operation");
+    }
 }

--- a/wsdl-core/src/test/resources/wsdl/combined_one_way_operation.wsdl
+++ b/wsdl-core/src/test/resources/wsdl/combined_one_way_operation.wsdl
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                   xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                   xmlns:tns="http://example.org/combined"
+                   targetNamespace="http://example.org/combined">
+
+    <wsdl:types>
+        <xs:schema targetNamespace="http://example.org/combined">
+            <xs:element name="echoRequest">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="message" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="echoResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="result" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="pingRequest">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="message" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:schema>
+    </wsdl:types>
+
+    <wsdl:message name="echoRequest">
+        <wsdl:part name="parameters" element="tns:echoRequest"/>
+    </wsdl:message>
+    <wsdl:message name="echoResponse">
+        <wsdl:part name="parameters" element="tns:echoResponse"/>
+    </wsdl:message>
+    <wsdl:message name="pingRequest">
+        <wsdl:part name="parameters" element="tns:pingRequest"/>
+    </wsdl:message>
+
+    <wsdl:portType name="CombinedServicePortType">
+        <wsdl:operation name="echo">
+            <wsdl:input message="tns:echoRequest"/>
+            <wsdl:output message="tns:echoResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="ping">
+            <wsdl:input message="tns:pingRequest"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="CombinedServiceSoap12Binding" type="tns:CombinedServicePortType">
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+        <wsdl:operation name="echo">
+            <soap12:operation soapAction="urn:echo"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="ping">
+            <soap12:operation soapAction="urn:ping"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="CombinedService">
+        <wsdl:port name="CombinedServiceSoap12Port" binding="tns:CombinedServiceSoap12Binding">
+            <soap12:address location="https://localhost:9443/services/CombinedService"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/wsdl-core/src/test/resources/wsdl/invalid_binding_output.wsdl
+++ b/wsdl-core/src/test/resources/wsdl/invalid_binding_output.wsdl
@@ -20,7 +20,7 @@
             <wsdl:output message="tns:DivideSoapOut"/>
         </wsdl:operation>
     </wsdl:portType>
-    <wsdl:binding name="CalculatorSoap12" >
+    <wsdl:binding name="CalculatorSoap12" type="tns:CalculatorSoap">
         <wsdl:operation name="Add">
             <soap12:operation soapAction="http://tempuri.org/Add" style="document"/>
             <wsdl:input>

--- a/wsdl-core/src/test/resources/wsdl/one_way_operation.wsdl
+++ b/wsdl-core/src/test/resources/wsdl/one_way_operation.wsdl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                   xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                   xmlns:tns="http://example.org/oneway"
+                   targetNamespace="http://example.org/oneway">
+
+    <wsdl:types>
+        <xs:schema targetNamespace="http://example.org/oneway">
+            <xs:element name="pingRequest">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="message" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:schema>
+    </wsdl:types>
+
+    <wsdl:message name="pingRequest">
+        <wsdl:part name="parameters" element="tns:pingRequest"/>
+    </wsdl:message>
+
+    <wsdl:portType name="PingServicePortType">
+        <wsdl:operation name="ping">
+            <wsdl:input message="tns:pingRequest"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="PingServiceSoap12Binding" type="tns:PingServicePortType">
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+        <wsdl:operation name="ping">
+            <soap12:operation soapAction="urn:ping"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="PingService">
+        <wsdl:port name="PingServiceSoap12Port" binding="tns:PingServiceSoap12Binding">
+            <soap12:address location="https://localhost:9443/services/PingService"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
## Purpose
>  Fixes: https://github.com/ballerina-platform/ballerina-library/issues/9151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds support for one-way WSDL operations.

- Generates request-only type definitions.
- Tracks one-way operations in the WSDL model.
- Generates `sendOnly` client methods that return `error?`.
- Preserves `sendReceive` handling for request-response operations.
- Adds tests for one-way and mixed-operation WSDL services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->